### PR TITLE
Set up GitHub Pages hosting

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+maleauthor.oscorp.net


### PR DESCRIPTION
## What

Sets this repo up for GitHub Pages hosting, as part of migrating off Netlify.

Adds a `CNAME` file so GitHub Pages serves the site at **maleauthor.oscorp.net**.

## Follow-up (outside this PR)

- GitHub Pages gets enabled (source: `main` / root) once this merges.
- DNS is pointed at GitHub Pages in Cloudflare.
- The site is removed from Netlify after the cutover. (This supersedes the earlier "reconfigure Netlify build" note — the site moves off Netlify entirely.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)